### PR TITLE
feat: 로그인 페이지 Modal 컴포넌트를 구현합니다.

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -19,6 +19,7 @@ export default function RootLayout({
           ...rootLayoutStyle,
         })}
       >
+        <div id="modal"></div>
         {children}
       </body>
     </html>

--- a/src/components/CannotLoginModal.tsx
+++ b/src/components/CannotLoginModal.tsx
@@ -67,6 +67,10 @@ const cannotLoginModalWrapperStyles = css.raw({
   height: "100vh",
 
   backgroundColor: "grayAlpha.800",
+
+  "@media (max-width: 480px)": {
+    alignItems: "flex-end",
+  },
 });
 
 const cannotLoginModalStyles = css.raw({
@@ -75,9 +79,15 @@ const cannotLoginModalStyles = css.raw({
   padding: "0 0.8rem",
   marginTop: "2.8rem",
 
-  borderRadius: "1.2rem",
+  borderRadius: "1.6rem",
 
   backgroundColor: "gray.800",
+
+  "@media (max-width: 480px)": {
+    width: "calc(100% - 3.2rem)",
+    height: "20.6rem",
+    marginBottom: "0.8rem",
+  },
 });
 
 const modalTitleStyles = css.raw({
@@ -95,6 +105,7 @@ const modalTitleStyles = css.raw({
 const iconAlertCircleStyles = css.raw({
   width: "2.4rem",
   height: "2.4rem",
+
   color: "white",
 });
 
@@ -104,4 +115,8 @@ const buttonListStyles = css.raw({
   gap: "1.2rem",
 
   marginTop: "1.2rem",
+
+  "@media (max-width: 480px)": {
+    gap: "0.4rem",
+  },
 });

--- a/src/components/CannotLoginModal.tsx
+++ b/src/components/CannotLoginModal.tsx
@@ -9,19 +9,20 @@ interface CannotLoginModalProps {
 }
 
 function CannotLoginModal({ handleCloseModal }: CannotLoginModalProps) {
-  const handleClickLoginAccountButton = (e: MouseEvent<HTMLButtonElement>) => {
-    // 버튼 눌러도 모달 안 닫히도록 설정
-    e.stopPropagation(); // 만약 버튼 누르고 모달 닫히도록 의도하고 싶으면 해당 라인 제거
-  };
+  const handleClickLoginAccountButton = (
+    e: MouseEvent<HTMLButtonElement>
+  ) => {};
 
-  const handleClickResetAccountButton = (e: MouseEvent<HTMLButtonElement>) => {
-    // 버튼 눌러도 모달 안 닫히도록 설정
-    e.stopPropagation(); // 만약 버튼 누르고 모달 닫히도록 의도하고 싶으면 해당 라인 제거
-  };
+  const handleClickResetAccountButton = (
+    e: MouseEvent<HTMLButtonElement>
+  ) => {};
 
-  const handleClickKakaoChannelButton = (e: MouseEvent<HTMLButtonElement>) => {
-    // 버튼 눌러도 모달 안 닫히도록 설정
-    e.stopPropagation(); // 만약 버튼 누르고 모달 닫히도록 의도하고 싶으면 해당 라인 제거
+  const handleClickKakaoChannelButton = (
+    e: MouseEvent<HTMLButtonElement>
+  ) => {};
+
+  const preventPropagation = (e: MouseEvent<HTMLDivElement>) => {
+    e.stopPropagation();
   };
 
   return (
@@ -30,7 +31,10 @@ function CannotLoginModal({ handleCloseModal }: CannotLoginModalProps) {
         className={css({ ...cannotLoginModalWrapperStyles })}
         onClick={handleCloseModal}
       >
-        <div className={css({ ...cannotLoginModalStyles })}>
+        <div
+          className={css({ ...cannotLoginModalStyles })}
+          onClick={preventPropagation}
+        >
           <h1 className={css({ ...modalTitleStyles })}>
             <IconAlertCircle className={css({ ...iconAlertCircleStyles })} />
             <span>로그인이 안 되나요?</span>
@@ -58,7 +62,7 @@ const cannotLoginModalWrapperStyles = css.raw({
   position: "absolute",
   top: "0",
   left: "0",
-  zIndex: "999",
+  zIndex: "1",
 
   display: "flex",
   justifyContent: "center",

--- a/src/components/CannotLoginModal.tsx
+++ b/src/components/CannotLoginModal.tsx
@@ -1,23 +1,107 @@
 import { css } from "@/styled-system/css";
-import React from "react";
+import { type MouseEvent } from "react";
 import CannotLoginModalPortal from "./CannotLoginModalPortal";
+import { IconAlertCircle } from "@sopt-makers/icons";
+import CannotLoginModalButton from "./CannotLoginModalButton";
 
-function CannotLoginModal() {
+interface CannotLoginModalProps {
+  handleCloseModal: () => void;
+}
+
+function CannotLoginModal({ handleCloseModal }: CannotLoginModalProps) {
+  const handleClickLoginAccountButton = (e: MouseEvent<HTMLButtonElement>) => {
+    // 버튼 눌러도 모달 안 닫히도록 설정
+    e.stopPropagation(); // 만약 버튼 누르고 모달 닫히도록 의도하고 싶으면 해당 라인 제거
+  };
+
+  const handleClickResetAccountButton = (e: MouseEvent<HTMLButtonElement>) => {
+    // 버튼 눌러도 모달 안 닫히도록 설정
+    e.stopPropagation(); // 만약 버튼 누르고 모달 닫히도록 의도하고 싶으면 해당 라인 제거
+  };
+
+  const handleClickKakaoChannelButton = (e: MouseEvent<HTMLButtonElement>) => {
+    // 버튼 눌러도 모달 안 닫히도록 설정
+    e.stopPropagation(); // 만약 버튼 누르고 모달 닫히도록 의도하고 싶으면 해당 라인 제거
+  };
+
   return (
     <CannotLoginModalPortal>
-      <div className={css({ ...cannotLogInModalStyles })}>CannotLoginModal</div>
+      <div
+        className={css({ ...cannotLoginModalWrapperStyles })}
+        onClick={handleCloseModal}
+      >
+        <div className={css({ ...cannotLoginModalStyles })}>
+          <h1 className={css({ ...modalTitleStyles })}>
+            <IconAlertCircle className={css({ ...iconAlertCircleStyles })} />
+            <span>로그인이 안 되나요?</span>
+          </h1>
+          <li className={css({ ...buttonListStyles })}>
+            <CannotLoginModalButton onClick={handleClickLoginAccountButton}>
+              로그인한 계정을 알고 싶어요.
+            </CannotLoginModalButton>
+            <CannotLoginModalButton onClick={handleClickResetAccountButton}>
+              소셜 계정을 재설정하고 싶어요.
+            </CannotLoginModalButton>
+            <CannotLoginModalButton onClick={handleClickKakaoChannelButton}>
+              카카오톡 채널에 문의할게요.
+            </CannotLoginModalButton>
+          </li>
+        </div>
+      </div>
     </CannotLoginModalPortal>
   );
 }
 
 export default CannotLoginModal;
 
-const cannotLogInModalStyles = css.raw({
+const cannotLoginModalWrapperStyles = css.raw({
   position: "absolute",
   top: "0",
   left: "0",
   zIndex: "999",
+
+  display: "flex",
+  justifyContent: "center",
+
   width: "100%",
   height: "100vh",
-  backgroundColor: "rgba(15, 15, 18, 0.8)",
+
+  backgroundColor: "grayAlpha.800",
+});
+
+const cannotLoginModalStyles = css.raw({
+  width: "41rem",
+  height: "22.2rem",
+  padding: "0 0.8rem",
+  marginTop: "2.8rem",
+
+  borderRadius: "1.2rem",
+
+  backgroundColor: "gray.800",
+});
+
+const modalTitleStyles = css.raw({
+  display: "flex",
+  alignItems: "center",
+  gap: "0.4rem",
+
+  marginTop: "1.6rem",
+  paddingLeft: "0.4rem",
+
+  textStyle: " title-4-20-sb",
+  color: "gray.10",
+});
+
+const iconAlertCircleStyles = css.raw({
+  width: "2.4rem",
+  height: "2.4rem",
+  color: "white",
+});
+
+const buttonListStyles = css.raw({
+  display: "flex",
+  flexDirection: "column",
+  gap: "1.2rem",
+
+  marginTop: "1.2rem",
 });

--- a/src/components/CannotLoginModal.tsx
+++ b/src/components/CannotLoginModal.tsx
@@ -1,0 +1,23 @@
+import { css } from "@/styled-system/css";
+import React from "react";
+import CannotLoginModalPortal from "./CannotLoginModalPortal";
+
+function CannotLoginModal() {
+  return (
+    <CannotLoginModalPortal>
+      <div className={css({ ...cannotLogInModalStyles })}>CannotLoginModal</div>
+    </CannotLoginModalPortal>
+  );
+}
+
+export default CannotLoginModal;
+
+const cannotLogInModalStyles = css.raw({
+  position: "absolute",
+  top: "0",
+  left: "0",
+  zIndex: "999",
+  width: "100%",
+  height: "100vh",
+  backgroundColor: "rgba(15, 15, 18, 0.8)",
+});

--- a/src/components/CannotLoginModalButton.tsx
+++ b/src/components/CannotLoginModalButton.tsx
@@ -1,0 +1,45 @@
+import { css } from "@/styled-system/css";
+import { type ButtonHTMLAttributes } from "react";
+
+interface CannotLoginModalButtonProps
+  extends ButtonHTMLAttributes<HTMLButtonElement> {
+  children: React.ReactNode;
+}
+
+function CannotLoginModalButton({
+  children,
+  ...buttonElementProps
+}: CannotLoginModalButtonProps) {
+  return (
+    <button
+      className={css({ ...cannotLoginModalButtonStyles })}
+      type="button"
+      {...buttonElementProps}
+    >
+      {children}
+    </button>
+  );
+}
+
+export default CannotLoginModalButton;
+
+const cannotLoginModalButtonStyles = css.raw({
+  display: "flex",
+
+  width: "100%",
+  height: "4.4rem",
+  padding: "1rem",
+
+  borderRadius: "1.2rem",
+
+  backgroundColor: "gray.800",
+
+  color: "gray.10",
+  textStyle: "body-2-16-r",
+
+  cursor: "pointer",
+
+  "&:hover": {
+    backgroundColor: "gray.700",
+  },
+});

--- a/src/components/CannotLoginModalButton.tsx
+++ b/src/components/CannotLoginModalButton.tsx
@@ -42,4 +42,8 @@ const cannotLoginModalButtonStyles = css.raw({
   "&:hover": {
     backgroundColor: "gray.700",
   },
+
+  "&:action": {
+    backgroundColor: "gray.600",
+  },
 });

--- a/src/components/CannotLoginModalPortal.tsx
+++ b/src/components/CannotLoginModalPortal.tsx
@@ -1,0 +1,17 @@
+import { ReactNode } from "react";
+import { createPortal } from "react-dom";
+
+interface PortalProps {
+  children: ReactNode;
+}
+
+function CannotLoginModalPortal({ children }: PortalProps) {
+  if (typeof window === "undefined") return null;
+
+  const modalElement = document.getElementById("modal");
+  if (!modalElement) return null;
+
+  return createPortal(children, modalElement);
+}
+
+export default CannotLoginModalPortal;

--- a/src/components/LoginSection.tsx
+++ b/src/components/LoginSection.tsx
@@ -7,7 +7,6 @@ import { IconChevronRight } from "@sopt-makers/icons";
 import LastLoggedInBanner from "./LastLoggedInBanner";
 import CannotLoginModal from "./CannotLoginModal";
 import { useState } from "react";
-import CannotLoginModalPortal from "./CannotLoginModalPortal";
 
 function LoginSection() {
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
@@ -16,9 +15,13 @@ function LoginSection() {
     setIsModalOpen(true);
   };
 
+  const handleCloseModal = () => {
+    setIsModalOpen(false);
+  };
+
   return (
     <>
-      {isModalOpen && <CannotLoginModal />}
+      {isModalOpen && <CannotLoginModal handleCloseModal={handleCloseModal} />}
       <div className={css({ ...loginSectionStyles })}>
         <LastLoggedInBanner />
         <section className={css({ ...loginButtonSectionStyles })}>

--- a/src/components/LoginSection.tsx
+++ b/src/components/LoginSection.tsx
@@ -5,34 +5,51 @@ import { css } from "@/styled-system/css";
 import LoginButton from "./LoginButton";
 import { IconChevronRight } from "@sopt-makers/icons";
 import LastLoggedInBanner from "./LastLoggedInBanner";
+import CannotLoginModal from "./CannotLoginModal";
+import { useState } from "react";
+import CannotLoginModalPortal from "./CannotLoginModalPortal";
 
 function LoginSection() {
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+
+  const handleClickCannotLoginButton = () => {
+    setIsModalOpen(true);
+  };
+
   return (
-    <div className={css({ ...loginSectionStyles })}>
-      <LastLoggedInBanner />
-      <section className={css({ ...loginButtonSectionStyles })}>
-        <LoginButton
-          buttonText="Google로 로그인"
-          buttonIcon={<img src="/google.svg" alt="구글 로고" />}
-        />
-        <LoginButton
-          buttonText="Apple로 로그인"
-          buttonIcon={<img src="/apple.svg" alt="애플 로고" />}
-        />
-      </section>
-      <button className={css({ ...cannotLoginButtonStyles })}>
-        <span className={css({ ...cannotLoginButtonTextStyles })}>
-          로그인이 안 되나요?
-        </span>
-        <IconChevronRight className={css({ ...iconChevronRightStyles })} />
-      </button>
-      <div className={css({ ...orWrapperStyles })}>
-        <div className={css({ ...orLineStyles })} />
-        <span className={css({ ...orTextStyles })}>또는</span>
-        <div className={css({ ...orLineStyles })} />
+    <>
+      {isModalOpen && <CannotLoginModal />}
+      <div className={css({ ...loginSectionStyles })}>
+        <LastLoggedInBanner />
+        <section className={css({ ...loginButtonSectionStyles })}>
+          <LoginButton
+            buttonText="Google로 로그인"
+            buttonIcon={<img src="/google.svg" alt="구글 로고" />}
+          />
+          <LoginButton
+            buttonText="Apple로 로그인"
+            buttonIcon={<img src="/apple.svg" alt="애플 로고" />}
+          />
+        </section>
+        <button
+          className={css({ ...cannotLoginButtonStyles })}
+          onClick={handleClickCannotLoginButton}
+        >
+          <span className={css({ ...cannotLoginButtonTextStyles })}>
+            로그인이 안 되나요?
+          </span>
+          <IconChevronRight className={css({ ...iconChevronRightStyles })} />
+        </button>
+        <div className={css({ ...orWrapperStyles })}>
+          <div className={css({ ...orLineStyles })} />
+          <span className={css({ ...orTextStyles })}>또는</span>
+          <div className={css({ ...orLineStyles })} />
+        </div>
+        <button className={css({ ...signUpButtonStyles })}>
+          SOPT 회원가입
+        </button>
       </div>
-      <button className={css({ ...signUpButtonStyles })}>SOPT 회원가입</button>
-    </div>
+    </>
   );
 }
 


### PR DESCRIPTION
부모 반응형 컨테이너 스타일 때문에 모달까지 영향을 받는 이슈가 있어 Portal을 사용하여 모달을 구현했어요.

모달 외부 영역을 클릭하면 모달이 닫히도록 Wrapper에 모달을 닫는 클릭 이벤트 핸들러를 바인딩했어요.
모달 각 옵션 버튼을 클릭하면 이벤트 전파로 인해 Wrapper에 바인딩된 모달을 닫는 이벤트 핸들러까지 동작하여 의도치 않게 모달이 닫히게 되므로, 이를 방지하기 위해 모달 컴포넌트 클릭 이벤트 핸들러에 `stopPropagation()`으로 이벤트 전파를 막아뒀어요.


https://github.com/user-attachments/assets/2a0420e8-ee19-4350-902f-0cb99cbf056b

