### PR TITLE
feat: 전화번호 인증 생성 API를 연결합니다.

### DIFF
--- a/src/api/postAuthPhone.ts
+++ b/src/api/postAuthPhone.ts
@@ -1,3 +1,9 @@
+interface PostAuthPhoneResponse {
+  success: boolean;
+  message: string;
+  data: any;
+}
+
 export const postAuthPhone = async (phone: string) => {
   const response = await fetch(
     `${import.meta.env.VITE_API_URL}/api/v1/auth/phone`,
@@ -10,9 +16,11 @@ export const postAuthPhone = async (phone: string) => {
     }
   );
 
+  const responseData: PostAuthPhoneResponse = await response.json();
+
   if (!response.ok) {
-    throw new Error("인증번호 발송에 실패했습니다.");
+    throw new Error(responseData.message);
   }
 
-  return response.json();
+  return responseData;
 };

--- a/src/api/postAuthPhone.ts
+++ b/src/api/postAuthPhone.ts
@@ -1,0 +1,18 @@
+export const postAuthPhone = async (phone: string) => {
+  const response = await fetch(
+    `${import.meta.env.VITE_API_URL}/api/v1/auth/phone`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ name: null, phone, type: "REGISTER" }),
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error("인증번호 발송에 실패했습니다.");
+  }
+
+  return response.json();
+};

--- a/src/components/common/AuthSection.tsx
+++ b/src/components/common/AuthSection.tsx
@@ -57,7 +57,7 @@ function AuthSection({ children, nextURL }: AuthSectionProps) {
       } catch (error) {
         if (error instanceof Error) {
           setPhoneNumberErrorMessage(
-            "인증번호 발송이 실패했습니다. 다시 시도해주세요."
+            "SOPT 활동 시 사용한 전화번호가 아니에요."
           );
         }
       }

--- a/src/components/common/AuthSection.tsx
+++ b/src/components/common/AuthSection.tsx
@@ -6,6 +6,7 @@ import { Button, TextField } from "@sopt-makers/ui";
 import { css, cx } from "@/styled-system/css";
 import { useTimer } from "@/src/hooks/useTimer";
 import { formatTime } from "@/src/utils/formatter";
+import { postAuthPhone } from "@/src/api/postAuthPhone";
 
 interface AuthSectionProps {
   children?: ReactNode;
@@ -41,18 +42,25 @@ function AuthSection({ children, nextURL }: AuthSectionProps) {
 
   const { timeLeft, resetTime } = useTimer(isActive, timerCallback, 10);
 
-  const handleSendAuthNumber = () => {
-    // LINK: https://www.notion.so/sopt-makers/8060b434d6db47aba4a32be0ef009d31?pvs=4
-    // TODO: API 함수 작성
-
+  const handleSendAuthNumber = async () => {
     if (phoneNumber === "") {
       setPhoneNumberErrorMessage("전화번호를 확인해주세요.");
     } else {
-      setAuthButtonText("재전송하기");
-      setAuthNumberErrorMessage("");
-      setPhoneNumberErrorMessage("");
-      resetTime();
-      setIsActive(true);
+      try {
+        await postAuthPhone(phoneNumber);
+
+        setAuthButtonText("재전송하기");
+        setAuthNumberErrorMessage("");
+        setPhoneNumberErrorMessage("");
+        resetTime();
+        setIsActive(true);
+      } catch (error) {
+        if (error instanceof Error) {
+          setPhoneNumberErrorMessage(
+            "인증번호 발송이 실패했습니다. 다시 시도해주세요."
+          );
+        }
+      }
     }
   };
 

--- a/src/components/common/AuthSection.tsx
+++ b/src/components/common/AuthSection.tsx
@@ -56,9 +56,7 @@ function AuthSection({ children, nextURL }: AuthSectionProps) {
         setIsActive(true);
       } catch (error) {
         if (error instanceof Error) {
-          setPhoneNumberErrorMessage(
-            "SOPT 활동 시 사용한 전화번호가 아니에요."
-          );
+          setPhoneNumberErrorMessage(error.message);
         }
       }
     }


### PR DESCRIPTION
전화번호 인증 API를 연결했어요.

### 성공 시
<img width="324" alt="image" src="https://github.com/user-attachments/assets/223d949c-eb9b-4577-a2a7-c7ed3defb9db" />

### 실패 시
<img width="324" alt="image" src="https://github.com/user-attachments/assets/8b48667d-cb5f-45f4-bee7-cce86d878113" />


DB에 이미 존재하는 번호에 대한 에러 케이스가 명세서에 없어서 일단은 임시로 `SOPT 활동 시 사용한 전화번호가 아니에요.` 라는 메시지를 에러 메시지로 설정해두었어요. 추후 다양한 에러 케이스에 대한 메시지 분기가 필요해보입니다!!