### PR TITLE
feat: 로그인 API를 연동합니다.

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@sopt-makers/icons": "^1.0.6",
     "@sopt-makers/ui": "^2.7.6",
     "@tanstack/react-router": "^1.97.1",
+    "jwt-decode": "^4.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,0 +1,11 @@
+export async function client(
+  endpoint: string,
+  options?: RequestInit
+): Promise<Response> {
+  if (import.meta.env.VITE_API_URL === undefined) {
+    throw new Error("환경변수에 API_URL을 등록해주세요.");
+  } else {
+    const url = new URL(endpoint, import.meta.env.VITE_API_URL).toString();
+    return fetch(url, options);
+  }
+}

--- a/src/api/constants/apiUrl.ts
+++ b/src/api/constants/apiUrl.ts
@@ -1,3 +1,3 @@
-export const API_URL = {
+export const API_ENDPOINT = {
   LOGIN: "/api/v1/auth/login/web",
 };

--- a/src/api/constants/apiUrl.ts
+++ b/src/api/constants/apiUrl.ts
@@ -1,0 +1,3 @@
+export const API_URL = {
+  LOGIN: "/api/v1/auth/login/web",
+};

--- a/src/api/postLogin.ts
+++ b/src/api/postLogin.ts
@@ -1,5 +1,5 @@
 import { client } from "./client";
-import { API_URL } from "./constants/apiUrl";
+import { API_ENDPOINT } from "./constants/apiUrl";
 
 export interface PostLoginRequest {
   authPlatform: "GOOGLE" | "APPLE";
@@ -18,7 +18,7 @@ export const postLogin = async ({
   authPlatform,
   token,
 }: PostLoginRequest): Promise<PostLoginResponse> => {
-  const response = await client(API_URL.LOGIN, {
+  const response = await client(API_ENDPOINT.LOGIN, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",

--- a/src/api/postLogin.ts
+++ b/src/api/postLogin.ts
@@ -1,0 +1,39 @@
+import { client } from "./client";
+import { API_URL } from "./constants/apiUrl";
+
+export interface PostLoginRequest {
+  authPlatform: "GOOGLE" | "APPLE";
+  token: string;
+}
+
+interface PostLoginResponse {
+  success: boolean;
+  message: string;
+  data: {
+    accessToken: string;
+  };
+}
+
+export const postLogin = async ({
+  authPlatform,
+  token,
+}: PostLoginRequest): Promise<PostLoginResponse> => {
+  const response = await client(API_URL.LOGIN, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      authPlatform,
+      token,
+    }),
+  });
+
+  const responseData = (await response.json()) as PostLoginResponse;
+
+  if (!response.ok) {
+    throw new Error(responseData.message);
+  }
+
+  return responseData;
+};

--- a/src/components/main/LastLoggedInBanner.tsx
+++ b/src/components/main/LastLoggedInBanner.tsx
@@ -1,10 +1,18 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { css } from "@/styled-system/css";
 
 function LastLoggedInBanner() {
   const [lastLoggedInAccount, setLastLoggedInAccount] = useState<
     "apple" | "google" | null
   >("google"); // 마지막으로 로그인한 계정
+
+  useEffect(() => {
+    const lastLoggedInAccount = localStorage.getItem("sopt-lastRegister");
+    if (lastLoggedInAccount === "google" || lastLoggedInAccount === "apple") {
+      setLastLoggedInAccount(lastLoggedInAccount);
+    }
+  }, []);
+
   return (
     <div className={css({ ...lastLoggedInBannerStyles })}>
       {lastLoggedInAccount && (

--- a/src/components/main/LoginSection.tsx
+++ b/src/components/main/LoginSection.tsx
@@ -8,6 +8,7 @@ import LastLoggedInBanner from "./LastLoggedInBanner";
 import CannotLoginModal from "@/src/components/common/CannotLoginModal";
 import { useState } from "react";
 import { Link } from "@tanstack/react-router";
+import { getGoogleAuthUrl } from "@/src/utils/google";
 
 function LoginSection() {
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
@@ -20,6 +21,13 @@ function LoginSection() {
     setIsModalOpen(false);
   };
 
+  const handleGoogleLogin = () => {
+    location.href = getGoogleAuthUrl();
+  };
+
+  // TODO: Apple Login 구현
+  // const handleAppleLogin = () => {};
+
   return (
     <>
       {isModalOpen && <CannotLoginModal handleCloseModal={handleCloseModal} />}
@@ -27,6 +35,7 @@ function LoginSection() {
         <LastLoggedInBanner />
         <section className={css({ ...loginButtonSectionStyles })}>
           <LoginButton
+            onClick={handleGoogleLogin}
             buttonText="Google로 로그인"
             buttonIcon={<img src="/google.svg" alt="구글 로고" />}
           />

--- a/src/hooks/useLogin.ts
+++ b/src/hooks/useLogin.ts
@@ -1,0 +1,25 @@
+import { postLogin, PostLoginRequest } from "@/src/api/postLogin";
+import { useNavigate } from "@tanstack/react-router";
+
+export const useLogin = () => {
+  const navigate = useNavigate();
+
+  const handleLogin = async ({ token, authPlatform }: PostLoginRequest) => {
+    try {
+      const response = await postLogin({ token, authPlatform });
+      localStorage.setItem("serviceAccessToken", response.data.accessToken);
+      // NOTE: 기존 pg-lastRegister를 sopt-lastRegister로 변경
+      localStorage.setItem(
+        "sopt-lastRegister",
+        authPlatform === "GOOGLE" ? "google" : "apple"
+      );
+    } catch (error) {
+      if (error instanceof Error) {
+        alert(error.message);
+      }
+    }
+    navigate({ to: "/" });
+  };
+
+  return { handleLogin };
+};

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -8,193 +8,214 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute } from '@tanstack/react-router'
 
 // Import Routes
 
-import { Route as rootRoute } from "./routes/__root";
+import { Route as rootRoute } from './routes/__root'
+import { Route as AuthGoogleCallbackIndexImport } from './routes/auth/google/callback/index'
 
 // Create Virtual Routes
 
-const IndexLazyImport = createFileRoute("/")();
-const LoginErrorIndexLazyImport = createFileRoute("/login-error/")();
+const IndexLazyImport = createFileRoute('/')()
+const LoginErrorIndexLazyImport = createFileRoute('/login-error/')()
 const SocialAccountLinkingSocialIndexLazyImport = createFileRoute(
-  "/social-account-linking/social/"
-)();
+  '/social-account-linking/social/',
+)()
 const SocialAccountLinkingAuthIndexLazyImport = createFileRoute(
-  "/social-account-linking/auth/"
-)();
-const SignUpSocialIndexLazyImport = createFileRoute("/sign-up/social/")();
-const SignUpAuthIndexLazyImport = createFileRoute("/sign-up/auth/")();
+  '/social-account-linking/auth/',
+)()
+const SignUpSocialIndexLazyImport = createFileRoute('/sign-up/social/')()
+const SignUpAuthIndexLazyImport = createFileRoute('/sign-up/auth/')()
 
 // Create/Update Routes
 
 const IndexLazyRoute = IndexLazyImport.update({
-  id: "/",
-  path: "/",
+  id: '/',
+  path: '/',
   getParentRoute: () => rootRoute,
-} as any).lazy(() => import("./routes/index.lazy").then((d) => d.Route));
+} as any).lazy(() => import('./routes/index.lazy').then((d) => d.Route))
 
 const LoginErrorIndexLazyRoute = LoginErrorIndexLazyImport.update({
-  id: "/login-error/",
-  path: "/login-error/",
+  id: '/login-error/',
+  path: '/login-error/',
   getParentRoute: () => rootRoute,
 } as any).lazy(() =>
-  import("./routes/login-error/index.lazy").then((d) => d.Route)
-);
+  import('./routes/login-error/index.lazy').then((d) => d.Route),
+)
 
 const SocialAccountLinkingSocialIndexLazyRoute =
   SocialAccountLinkingSocialIndexLazyImport.update({
-    id: "/social-account-linking/social/",
-    path: "/social-account-linking/social/",
+    id: '/social-account-linking/social/',
+    path: '/social-account-linking/social/',
     getParentRoute: () => rootRoute,
   } as any).lazy(() =>
-    import("./routes/social-account-linking/social/index.lazy").then(
-      (d) => d.Route
-    )
-  );
+    import('./routes/social-account-linking/social/index.lazy').then(
+      (d) => d.Route,
+    ),
+  )
 
 const SocialAccountLinkingAuthIndexLazyRoute =
   SocialAccountLinkingAuthIndexLazyImport.update({
-    id: "/social-account-linking/auth/",
-    path: "/social-account-linking/auth/",
+    id: '/social-account-linking/auth/',
+    path: '/social-account-linking/auth/',
     getParentRoute: () => rootRoute,
   } as any).lazy(() =>
-    import("./routes/social-account-linking/auth/index.lazy").then(
-      (d) => d.Route
-    )
-  );
+    import('./routes/social-account-linking/auth/index.lazy').then(
+      (d) => d.Route,
+    ),
+  )
 
 const SignUpSocialIndexLazyRoute = SignUpSocialIndexLazyImport.update({
-  id: "/sign-up/social/",
-  path: "/sign-up/social/",
+  id: '/sign-up/social/',
+  path: '/sign-up/social/',
   getParentRoute: () => rootRoute,
 } as any).lazy(() =>
-  import("./routes/sign-up/social/index.lazy").then((d) => d.Route)
-);
+  import('./routes/sign-up/social/index.lazy').then((d) => d.Route),
+)
 
 const SignUpAuthIndexLazyRoute = SignUpAuthIndexLazyImport.update({
-  id: "/sign-up/auth/",
-  path: "/sign-up/auth/",
+  id: '/sign-up/auth/',
+  path: '/sign-up/auth/',
   getParentRoute: () => rootRoute,
 } as any).lazy(() =>
-  import("./routes/sign-up/auth/index.lazy").then((d) => d.Route)
-);
+  import('./routes/sign-up/auth/index.lazy').then((d) => d.Route),
+)
+
+const AuthGoogleCallbackIndexRoute = AuthGoogleCallbackIndexImport.update({
+  id: '/auth/google/callback/',
+  path: '/auth/google/callback/',
+  getParentRoute: () => rootRoute,
+} as any)
 
 // Populate the FileRoutesByPath interface
 
-declare module "@tanstack/react-router" {
+declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    "/": {
-      id: "/";
-      path: "/";
-      fullPath: "/";
-      preLoaderRoute: typeof IndexLazyImport;
-      parentRoute: typeof rootRoute;
-    };
-    "/login-error/": {
-      id: "/login-error/";
-      path: "/login-error";
-      fullPath: "/login-error";
-      preLoaderRoute: typeof LoginErrorIndexLazyImport;
-      parentRoute: typeof rootRoute;
-    };
-    "/sign-up/auth/": {
-      id: "/sign-up/auth/";
-      path: "/sign-up/auth";
-      fullPath: "/sign-up/auth";
-      preLoaderRoute: typeof SignUpAuthIndexLazyImport;
-      parentRoute: typeof rootRoute;
-    };
-    "/sign-up/social/": {
-      id: "/sign-up/social/";
-      path: "/sign-up/social";
-      fullPath: "/sign-up/social";
-      preLoaderRoute: typeof SignUpSocialIndexLazyImport;
-      parentRoute: typeof rootRoute;
-    };
-    "/social-account-linking/auth/": {
-      id: "/social-account-linking/auth/";
-      path: "/social-account-linking/auth";
-      fullPath: "/social-account-linking/auth";
-      preLoaderRoute: typeof SocialAccountLinkingAuthIndexLazyImport;
-      parentRoute: typeof rootRoute;
-    };
-    "/social-account-linking/social/": {
-      id: "/social-account-linking/social/";
-      path: "/social-account-linking/social";
-      fullPath: "/social-account-linking/social";
-      preLoaderRoute: typeof SocialAccountLinkingSocialIndexLazyImport;
-      parentRoute: typeof rootRoute;
-    };
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexLazyImport
+      parentRoute: typeof rootRoute
+    }
+    '/login-error/': {
+      id: '/login-error/'
+      path: '/login-error'
+      fullPath: '/login-error'
+      preLoaderRoute: typeof LoginErrorIndexLazyImport
+      parentRoute: typeof rootRoute
+    }
+    '/sign-up/auth/': {
+      id: '/sign-up/auth/'
+      path: '/sign-up/auth'
+      fullPath: '/sign-up/auth'
+      preLoaderRoute: typeof SignUpAuthIndexLazyImport
+      parentRoute: typeof rootRoute
+    }
+    '/sign-up/social/': {
+      id: '/sign-up/social/'
+      path: '/sign-up/social'
+      fullPath: '/sign-up/social'
+      preLoaderRoute: typeof SignUpSocialIndexLazyImport
+      parentRoute: typeof rootRoute
+    }
+    '/social-account-linking/auth/': {
+      id: '/social-account-linking/auth/'
+      path: '/social-account-linking/auth'
+      fullPath: '/social-account-linking/auth'
+      preLoaderRoute: typeof SocialAccountLinkingAuthIndexLazyImport
+      parentRoute: typeof rootRoute
+    }
+    '/social-account-linking/social/': {
+      id: '/social-account-linking/social/'
+      path: '/social-account-linking/social'
+      fullPath: '/social-account-linking/social'
+      preLoaderRoute: typeof SocialAccountLinkingSocialIndexLazyImport
+      parentRoute: typeof rootRoute
+    }
+    '/auth/google/callback/': {
+      id: '/auth/google/callback/'
+      path: '/auth/google/callback'
+      fullPath: '/auth/google/callback'
+      preLoaderRoute: typeof AuthGoogleCallbackIndexImport
+      parentRoute: typeof rootRoute
+    }
   }
 }
 
 // Create and export the route tree
 
 export interface FileRoutesByFullPath {
-  "/": typeof IndexLazyRoute;
-  "/login-error": typeof LoginErrorIndexLazyRoute;
-  "/sign-up/auth": typeof SignUpAuthIndexLazyRoute;
-  "/sign-up/social": typeof SignUpSocialIndexLazyRoute;
-  "/social-account-linking/auth": typeof SocialAccountLinkingAuthIndexLazyRoute;
-  "/social-account-linking/social": typeof SocialAccountLinkingSocialIndexLazyRoute;
+  '/': typeof IndexLazyRoute
+  '/login-error': typeof LoginErrorIndexLazyRoute
+  '/sign-up/auth': typeof SignUpAuthIndexLazyRoute
+  '/sign-up/social': typeof SignUpSocialIndexLazyRoute
+  '/social-account-linking/auth': typeof SocialAccountLinkingAuthIndexLazyRoute
+  '/social-account-linking/social': typeof SocialAccountLinkingSocialIndexLazyRoute
+  '/auth/google/callback': typeof AuthGoogleCallbackIndexRoute
 }
 
 export interface FileRoutesByTo {
-  "/": typeof IndexLazyRoute;
-  "/login-error": typeof LoginErrorIndexLazyRoute;
-  "/sign-up/auth": typeof SignUpAuthIndexLazyRoute;
-  "/sign-up/social": typeof SignUpSocialIndexLazyRoute;
-  "/social-account-linking/auth": typeof SocialAccountLinkingAuthIndexLazyRoute;
-  "/social-account-linking/social": typeof SocialAccountLinkingSocialIndexLazyRoute;
+  '/': typeof IndexLazyRoute
+  '/login-error': typeof LoginErrorIndexLazyRoute
+  '/sign-up/auth': typeof SignUpAuthIndexLazyRoute
+  '/sign-up/social': typeof SignUpSocialIndexLazyRoute
+  '/social-account-linking/auth': typeof SocialAccountLinkingAuthIndexLazyRoute
+  '/social-account-linking/social': typeof SocialAccountLinkingSocialIndexLazyRoute
+  '/auth/google/callback': typeof AuthGoogleCallbackIndexRoute
 }
 
 export interface FileRoutesById {
-  __root__: typeof rootRoute;
-  "/": typeof IndexLazyRoute;
-  "/login-error/": typeof LoginErrorIndexLazyRoute;
-  "/sign-up/auth/": typeof SignUpAuthIndexLazyRoute;
-  "/sign-up/social/": typeof SignUpSocialIndexLazyRoute;
-  "/social-account-linking/auth/": typeof SocialAccountLinkingAuthIndexLazyRoute;
-  "/social-account-linking/social/": typeof SocialAccountLinkingSocialIndexLazyRoute;
+  __root__: typeof rootRoute
+  '/': typeof IndexLazyRoute
+  '/login-error/': typeof LoginErrorIndexLazyRoute
+  '/sign-up/auth/': typeof SignUpAuthIndexLazyRoute
+  '/sign-up/social/': typeof SignUpSocialIndexLazyRoute
+  '/social-account-linking/auth/': typeof SocialAccountLinkingAuthIndexLazyRoute
+  '/social-account-linking/social/': typeof SocialAccountLinkingSocialIndexLazyRoute
+  '/auth/google/callback/': typeof AuthGoogleCallbackIndexRoute
 }
 
 export interface FileRouteTypes {
-  fileRoutesByFullPath: FileRoutesByFullPath;
+  fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
-    | "/"
-    | "/login-error"
-    | "/sign-up/auth"
-    | "/sign-up/social"
-    | "/social-account-linking/auth"
-    | "/social-account-linking/social";
-  fileRoutesByTo: FileRoutesByTo;
+    | '/'
+    | '/login-error'
+    | '/sign-up/auth'
+    | '/sign-up/social'
+    | '/social-account-linking/auth'
+    | '/social-account-linking/social'
+    | '/auth/google/callback'
+  fileRoutesByTo: FileRoutesByTo
   to:
-    | "/"
-    | "/login-error"
-    | "/sign-up/auth"
-    | "/sign-up/social"
-    | "/social-account-linking/auth"
-    | "/social-account-linking/social";
+    | '/'
+    | '/login-error'
+    | '/sign-up/auth'
+    | '/sign-up/social'
+    | '/social-account-linking/auth'
+    | '/social-account-linking/social'
+    | '/auth/google/callback'
   id:
-    | "__root__"
-    | "/"
-    | "/login-error/"
-    | "/sign-up/auth/"
-    | "/sign-up/social/"
-    | "/social-account-linking/auth/"
-    | "/social-account-linking/social/";
-  fileRoutesById: FileRoutesById;
+    | '__root__'
+    | '/'
+    | '/login-error/'
+    | '/sign-up/auth/'
+    | '/sign-up/social/'
+    | '/social-account-linking/auth/'
+    | '/social-account-linking/social/'
+    | '/auth/google/callback/'
+  fileRoutesById: FileRoutesById
 }
 
 export interface RootRouteChildren {
-  IndexLazyRoute: typeof IndexLazyRoute;
-  LoginErrorIndexLazyRoute: typeof LoginErrorIndexLazyRoute;
-  SignUpAuthIndexLazyRoute: typeof SignUpAuthIndexLazyRoute;
-  SignUpSocialIndexLazyRoute: typeof SignUpSocialIndexLazyRoute;
-  SocialAccountLinkingAuthIndexLazyRoute: typeof SocialAccountLinkingAuthIndexLazyRoute;
-  SocialAccountLinkingSocialIndexLazyRoute: typeof SocialAccountLinkingSocialIndexLazyRoute;
+  IndexLazyRoute: typeof IndexLazyRoute
+  LoginErrorIndexLazyRoute: typeof LoginErrorIndexLazyRoute
+  SignUpAuthIndexLazyRoute: typeof SignUpAuthIndexLazyRoute
+  SignUpSocialIndexLazyRoute: typeof SignUpSocialIndexLazyRoute
+  SocialAccountLinkingAuthIndexLazyRoute: typeof SocialAccountLinkingAuthIndexLazyRoute
+  SocialAccountLinkingSocialIndexLazyRoute: typeof SocialAccountLinkingSocialIndexLazyRoute
+  AuthGoogleCallbackIndexRoute: typeof AuthGoogleCallbackIndexRoute
 }
 
 const rootRouteChildren: RootRouteChildren = {
@@ -206,11 +227,12 @@ const rootRouteChildren: RootRouteChildren = {
     SocialAccountLinkingAuthIndexLazyRoute,
   SocialAccountLinkingSocialIndexLazyRoute:
     SocialAccountLinkingSocialIndexLazyRoute,
-};
+  AuthGoogleCallbackIndexRoute: AuthGoogleCallbackIndexRoute,
+}
 
 export const routeTree = rootRoute
   ._addFileChildren(rootRouteChildren)
-  ._addFileTypes<FileRouteTypes>();
+  ._addFileTypes<FileRouteTypes>()
 
 /* ROUTE_MANIFEST_START
 {
@@ -223,7 +245,8 @@ export const routeTree = rootRoute
         "/sign-up/auth/",
         "/sign-up/social/",
         "/social-account-linking/auth/",
-        "/social-account-linking/social/"
+        "/social-account-linking/social/",
+        "/auth/google/callback/"
       ]
     },
     "/": {
@@ -243,6 +266,9 @@ export const routeTree = rootRoute
     },
     "/social-account-linking/social/": {
       "filePath": "social-account-linking/social/index.lazy.tsx"
+    },
+    "/auth/google/callback/": {
+      "filePath": "auth/google/callback/index.tsx"
     }
   }
 }

--- a/src/routes/auth/google/callback/index.tsx
+++ b/src/routes/auth/google/callback/index.tsx
@@ -1,0 +1,47 @@
+import { useEffect } from "react";
+import { useLogin } from "@/src/hooks/useLogin";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { jwtDecode } from "jwt-decode";
+import { validateNonce } from "@/src/utils/nonce";
+
+interface GoogleCallbackSearch {
+  token: string;
+}
+
+export const Route = createFileRoute("/auth/google/callback/")({
+  validateSearch: (search: Record<string, unknown>): GoogleCallbackSearch => {
+    return {
+      token: search.token as string,
+    };
+  },
+  component: Index,
+});
+
+function Index() {
+  const navigate = useNavigate();
+  const { handleLogin } = useLogin();
+
+  useEffect(() => {
+    const hash = window.location.hash.substring(1);
+    const params = new URLSearchParams(hash);
+    const token = params.get("id_token");
+
+    if (!token) {
+      alert("잘못된 접근입니다. 다시 시도해주세요");
+      navigate({ to: "/" });
+    } else {
+      const decoded = jwtDecode(token);
+
+      if (!validateNonce(decoded)) {
+        alert("토큰이 유효하지 않습니다. 다시 로그인 해주세요");
+        navigate({ to: "/" });
+      }
+
+      handleLogin({ token, authPlatform: "GOOGLE" });
+    }
+  }, [navigate, handleLogin]);
+
+  return <></>;
+}
+
+export default Index;

--- a/src/utils/formatter.ts
+++ b/src/utils/formatter.ts
@@ -1,4 +1,4 @@
-export const formatTime = (time: number) => {
+export const formatTime = (time: number): string => {
   const minutes = Math.floor(time / 60);
   const seconds = time % 60;
   return `${minutes}:${seconds.toString().padStart(2, "0")}`;

--- a/src/utils/google.ts
+++ b/src/utils/google.ts
@@ -1,0 +1,24 @@
+import { generateNonce } from "./nonce";
+
+export const getGoogleAuthUrl = (): string => {
+  const { VITE_GOOGLE_CLIENT_ID, VITE_GOOGLE_REDIRECT_URI } = import.meta.env;
+
+  if (!VITE_GOOGLE_CLIENT_ID || !VITE_GOOGLE_REDIRECT_URI) {
+    throw new Error("환경 변수에 Google OAuth 정보를 추가해주세요.");
+  }
+
+  const nonce = generateNonce();
+  sessionStorage.setItem("nonce", nonce);
+
+  const baseUrl = "https://accounts.google.com/o/oauth2/v2/auth";
+
+  const params = new URLSearchParams({
+    client_id: VITE_GOOGLE_CLIENT_ID,
+    redirect_uri: VITE_GOOGLE_REDIRECT_URI,
+    response_type: "id_token",
+    scope: "openid email profile",
+    nonce,
+  });
+
+  return `${baseUrl}?${params.toString()}`;
+};

--- a/src/utils/nonce.ts
+++ b/src/utils/nonce.ts
@@ -1,0 +1,18 @@
+// NOTE: OIDC + id_token 사용을 위한 nonce 난수 생성 함수
+export const generateNonce = (length = 16): string => {
+  const array = new Uint8Array(length);
+  window.crypto.getRandomValues(array);
+  return [...array].map((b) => b.toString(16).padStart(2, "0")).join("");
+};
+
+// NOTE: nonce 검증 함수
+export function validateNonce(
+  decodedIdToken: any,
+  storageKey = "nonce"
+): boolean {
+  const storedNonce = sessionStorage.getItem(storageKey);
+  if (!storedNonce || !decodedIdToken || decodedIdToken.nonce !== storedNonce) {
+    return false;
+  }
+  return true;
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -5,7 +5,3 @@ interface ImportMetaEnv {
   readonly VITE_GOOGLE_CLIENT_ID: string;
   readonly VITE_GOOGLE_REDIRECT_URI: string;
 }
-
-interface ImportMeta {
-  readonly env: ImportMetaEnv;
-}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,11 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_URL: string;
+  readonly VITE_GOOGLE_CLIENT_ID: string;
+  readonly VITE_GOOGLE_REDIRECT_URI: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3777,6 +3777,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jwt-decode@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "jwt-decode@npm:4.0.0"
+  checksum: 10c0/de75bbf89220746c388cf6a7b71e56080437b77d2edb29bae1c2155048b02c6b8c59a3e5e8d6ccdfd54f0b8bda25226e491a4f1b55ac5f8da04cfbadec4e546c
+  languageName: node
+  linkType: hard
+
 "keyv@npm:^4.5.4":
   version: 4.5.4
   resolution: "keyv@npm:4.5.4"
@@ -4897,6 +4904,7 @@ __metadata:
     eslint-plugin-react-hooks: "npm:^5.0.0"
     eslint-plugin-react-refresh: "npm:^0.4.16"
     globals: "npm:^15.14.0"
+    jwt-decode: "npm:^4.0.0"
     react: "npm:^19.0.0"
     react-dom: "npm:^19.0.0"
     typescript: "npm:~5.6.2"


### PR DESCRIPTION
## 변경사항

<!-- 어떤 변경사항이 있는지, PR 타이틀과 동일하다면 Skip -->

close #14

- google social 로그인 &  login api를 연동했어요. 현재 저희 구글 소셜로그인은 OAuth 2.0 프로토콜을 기반으로한 OIDC을 사용하고 있어요. 
  - 구글에서는 OIDC + id_token 으로 인증 시 nonce 값을 필수로 보내고, 다시 응답을 받을 때 nonce값을 검증하여 위변조가 되었는지 체킹한다고 해요. 그래서 nonce 생성함수와 검증 함수를 생성했어요. `utils/nonce.ts`
- nonce는 로그인 진행 전 sessionStorage에 저장하고, 로그인 이후에 nonce 값을 검증할 수 있게 했어요.
- 로그인 이후 atk는 `serviceAccessToken`(기존 플그 로그인과 동일) 라는 키 값으로 , 마지막으로 로그인한 소셜 계정은 `sopt-lastRegister`(기존 플그의 경우 pg-lastRegister)라는 키 값으로 로컬스토리지에 저장해두었어요.
- Vite의 환경 변수 타입을 추가해주었어요.
- google / apple callback url 을 라우팅해주었어요. -> l`ocalhost:5173/auth/google( or apple)/callback`
- 로그인 실패했을 때 UI가 없어서 일단 alert에 임시 문구를 작성해서 처리했어요.

- 로그인 이후에는 UI가 딱히 없어서 일단 홈으로 라우팅 해놓았습니다...!


> strict 모드라서 alert 창이 두번 뜨고있는점 참고 부탁드립니다.

https://github.com/user-attachments/assets/db3b50c5-3219-4dc7-9c9a-d2c8f4f28bfd

## 시급한 정도

🏃‍♂️ 보통 : 최대한 빠르게 리뷰 부탁드립니다.

<!-- ⚠︎ 긴급 : 선 어프루브 후 리뷰를 부탁드립니다. (리뷰는 추후 반영)  -->
<!-- 🐢 천천히 : 급하지 않습니다. -->