### PR TITLE
feat: 번호 인증 검사 API를 연동합니다.

### DIFF
--- a/src/api/postVerifyPhone.ts
+++ b/src/api/postVerifyPhone.ts
@@ -1,0 +1,31 @@
+interface PostVerifyPhoneResponse {
+  success: boolean;
+  message: string;
+  data: any;
+}
+
+export const postVerifyPhone = async (phone: string, code: string) => {
+  const response = await fetch(
+    `${import.meta.env.VITE_API_URL}/api/v1/auth/verify/phone`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        name: "Mock-Success-Register",
+        phone,
+        code,
+        type: "REGISTER",
+      }),
+    }
+  );
+
+  const responseData: PostVerifyPhoneResponse = await response.json();
+
+  if (!response.ok) {
+    throw new Error(responseData.message);
+  }
+
+  return responseData;
+};

--- a/src/components/common/AuthSection.tsx
+++ b/src/components/common/AuthSection.tsx
@@ -7,6 +7,7 @@ import { css, cx } from "@/styled-system/css";
 import { useTimer } from "@/src/hooks/useTimer";
 import { formatTime } from "@/src/utils/formatter";
 import { postAuthPhone } from "@/src/api/postAuthPhone";
+import { postVerifyPhone } from "@/src/api/postVerifyPhone";
 
 interface AuthSectionProps {
   children?: ReactNode;
@@ -50,6 +51,7 @@ function AuthSection({ children, nextURL }: AuthSectionProps) {
         await postAuthPhone(phoneNumber);
 
         setAuthButtonText("재전송하기");
+        setAuthNumber("");
         setAuthNumberErrorMessage("");
         setPhoneNumberErrorMessage("");
         resetTime();
@@ -62,11 +64,17 @@ function AuthSection({ children, nextURL }: AuthSectionProps) {
     }
   };
 
-  const handleAuthComplete = () => {
-    // LINK: https://www.notion.so/sopt-makers/ded309d5ff9a40a184c25816eb96e084?pvs=4
-    // TODO: API 함수 작성
+  const handleAuthComplete = async () => {
+    try {
+      await postVerifyPhone(phoneNumber, authNumber);
 
-    navigate({ to: nextURL });
+      setAuthNumberErrorMessage("");
+      navigate({ to: nextURL });
+    } catch (error) {
+      if (error instanceof Error) {
+        setAuthNumberErrorMessage(error.message);
+      }
+    }
   };
 
   return (


### PR DESCRIPTION
close #20 

번호 인증 검사 API를 연동했어요.
에러 메시지는 서버에서 보내주는 에러 메시지를 바인딩해요.


https://github.com/user-attachments/assets/13a9158f-5eef-40ea-958e-d6240e2ec442

추후 대원이형이 만들어준 client 모듈로 마이그레이션 예정이에요.