### PR TITLE
fix: 회원인증 페이지 layout shift 이슈를 해결합니다.

### DIFF
--- a/src/components/common/AuthSection.tsx
+++ b/src/components/common/AuthSection.tsx
@@ -20,8 +20,8 @@ function AuthSection({ children, nextURL }: AuthSectionProps) {
   const [authNumberErrorMessage, setAuthNumberErrorMessage] = useState("");
   const [phoneNumberErrorMessage, setPhoneNumberErrorMessage] = useState("");
   const [authButtonText, setAuthButtonText] = useState<
-    "인증번호 받기" | "재전송하기"
-  >("인증번호 받기");
+    "전송하기" | "재전송하기"
+  >("전송하기");
   const [isActive, setIsActive] = useState(false);
 
   const navigate = useNavigate();

--- a/src/components/common/AuthSection.tsx
+++ b/src/components/common/AuthSection.tsx
@@ -90,7 +90,12 @@ function AuthSection({ children, nextURL }: AuthSectionProps) {
             errorMessage={phoneNumberErrorMessage}
             className={css({ ...phoneInputStyles })}
           />
-          <Button onClick={handleSendAuthNumber}>{authButtonText}</Button>
+          <Button
+            className={css({ ...sendAuthNumberButtonStyles })}
+            onClick={handleSendAuthNumber}
+          >
+            {authButtonText}
+          </Button>
         </div>
         <div className={css({ ...authNumberWrapperStyles })}>
           <TextField
@@ -201,5 +206,13 @@ const completeButtonStyles = css.raw({
   "@media (max-width: 480px)": {
     marginTop: "auto",
     marginBottom: "3.4rem",
+  },
+});
+
+const sendAuthNumberButtonStyles = css.raw({
+  width: "11.6rem",
+
+  "@media (max-width: 480px)": {
+    width: "11rem",
   },
 });


### PR DESCRIPTION
close #23 

MDS Button은 size를 padding으로 조절하고 있어요.

```ts
export const paddings: Record<ButtonSizeTheme, string> = {
  sm: '9px 14px',
  md: '12px 20px',
  lg: '16px 26px',
};
```

저희의 경우 동일한 Button에서 텍스트를 갈아끼워야하는 상황이다보니 MDS 버튼을 사용했을 때 텍스트 길이가 변경되면 Button의 크기까지 달라져버리게 돼요. 컨텐츠 전체 너비가 Button Element의 size에 의존하고 있다보니 Button text가 변경될 때 Button size까지 변경되어 컨텐츠 전체 너비가 달라졌던 것이 layout shift의 원인이었어요.

그래서 Button size를 고정시켜두는 방식으로 layout shift를 해결했어요.

https://github.com/user-attachments/assets/6b048bfe-b2b2-4c88-b7d4-915b76828aa9



