### PR TITLE
feat: 리다이렉트 로직 추가

### DIFF
--- a/src/api/postLogin.ts
+++ b/src/api/postLogin.ts
@@ -11,6 +11,7 @@ interface PostLoginResponse {
   message: string;
   data: {
     accessToken: string;
+    isFirstLogin: boolean;
   };
 }
 

--- a/src/hooks/useLogin.ts
+++ b/src/hooks/useLogin.ts
@@ -11,9 +11,20 @@ export const useLogin = () => {
       localStorage.setItem('serviceAccessToken', response.data.accessToken);
       // NOTE: 기존 pg-lastRegister를 sopt-lastRegister로 변경
       localStorage.setItem('sopt-lastRegister', authPlatform === 'GOOGLE' ? 'google' : 'apple');
+      const lastUnauthorizedPath = sessionStorage.getItem('lastUnauthorizedPath');
 
       // NOTE: 서버 테스트용 복사 프롬프트 주석처리
       // prompt('서버테스트용 액세스 토큰 추출 (Ctrl+C로 복사하세요):', response.data.accessToken);
+
+      if (response.data?.isFirstLogin === true) {
+        window.location.href = `${VITE_SUCCESS_CALLBACK}/members/edit`;
+        return;
+      }
+
+      if (lastUnauthorizedPath) {
+        window.location.href = lastUnauthorizedPath;
+        return;
+      }
 
       window.location.href = VITE_SUCCESS_CALLBACK;
     } catch (error) {


### PR DESCRIPTION
- [리다이렉트 플로우 노션 링크](https://www.notion.so/sopt-makers/22-25476042aac280a7b700d31bd070cae6?source=copy_link)
- 로그인 flow (우선 순위) ->
    1. 프로필 등록이 안된 경우 서버 응답으로 받은 flag를 기반으로 프로필 설정 페이지로 이동 (isFirstLogin) - 도메인/members/edit
    2. 로그인 안한 상태로 접속한 페이지가 저장되어있다면 해당 링크로 이동 
    3. 홈으로 이동
