### PR TITLE
feat: QA 반영 [ 전화 번호 인증 화면 / 소셜계정 재설정 / 바텀 시트 - 카카오톡 채널 로직 ]

### DIFF
--- a/src/api/postAuthPhone.ts
+++ b/src/api/postAuthPhone.ts
@@ -1,20 +1,22 @@
+interface PostAuthPhoneRequest {
+  phone: string;
+  type?: 'REGISTER' | 'CHANGE_SOCIAL_PLATFORM';
+}
+
 interface PostAuthPhoneResponse {
   success: boolean;
   message: string;
   data: unknown;
 }
 
-export const postAuthPhone = async (phone: string) => {
-  const response = await fetch(
-    `${import.meta.env.VITE_API_URL}/api/v1/auth/phone`,
-    {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({ name: null, phone, type: "REGISTER" }),
-    }
-  );
+export const postAuthPhone = async ({ phone, type = 'REGISTER' }: PostAuthPhoneRequest) => {
+  const response = await fetch(`${import.meta.env.VITE_API_URL}/api/v1/auth/phone`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ name: null, phone, type }),
+  });
 
   const responseData: PostAuthPhoneResponse = await response.json();
 

--- a/src/api/postVerifyPhone.ts
+++ b/src/api/postVerifyPhone.ts
@@ -1,3 +1,9 @@
+interface PostVerifyPhoneRequest {
+  phone: string;
+  code: string;
+  type?: 'REGISTER' | 'CHANGE_SOCIAL_PLATFORM';
+}
+
 interface PostVerifyPhoneResponse {
   success: boolean;
   message: string;
@@ -7,7 +13,7 @@ interface PostVerifyPhoneResponse {
   };
 }
 
-export const postVerifyPhone = async (phone: string, code: string) => {
+export const postVerifyPhone = async ({ phone, code, type = 'REGISTER' }: PostVerifyPhoneRequest) => {
   const response = await fetch(`${import.meta.env.VITE_API_URL}/api/v1/auth/verify/phone`, {
     method: 'POST',
     headers: {
@@ -17,7 +23,7 @@ export const postVerifyPhone = async (phone: string, code: string) => {
       name: 'Mock-Success-Register',
       phone,
       code,
-      type: 'REGISTER',
+      type,
     }),
   });
 

--- a/src/components/common/CannotLoginModal.tsx
+++ b/src/components/common/CannotLoginModal.tsx
@@ -1,9 +1,9 @@
-import { css } from "@/styled-system/css";
-import { type MouseEvent } from "react";
-import CannotLoginModalPortal from "./CannotLoginModalPortal";
-import { IconAlertCircle } from "@sopt-makers/icons";
-import CannotLoginModalButton from "./CannotLoginModalButton";
-import { Link } from "@tanstack/react-router";
+import { css } from '@/styled-system/css';
+import { type MouseEvent } from 'react';
+import CannotLoginModalPortal from './CannotLoginModalPortal';
+import { IconAlertCircle } from '@sopt-makers/icons';
+import CannotLoginModalButton from './CannotLoginModalButton';
+import { Link } from '@tanstack/react-router';
 
 interface CannotLoginModalProps {
   handleCloseModal: () => void;
@@ -14,9 +14,9 @@ function CannotLoginModal({ handleCloseModal }: CannotLoginModalProps) {
     /** navigate */
   };
 
-  const handleClickKakaoChannelButton = (
-  ) => {
+  const handleClickKakaoChannelButton = () => {
     /** navigate */
+    window.location.href = import.meta.env.VITE_KAKAO_CHANNEL_URL;
   };
 
   const preventPropagation = (e: MouseEvent<HTMLDivElement>) => {
@@ -25,26 +25,18 @@ function CannotLoginModal({ handleCloseModal }: CannotLoginModalProps) {
 
   return (
     <CannotLoginModalPortal>
-      <div
-        className={css({ ...cannotLoginModalWrapperStyles })}
-        onClick={handleCloseModal}
-      >
-        <div
-          className={css({ ...cannotLoginModalStyles })}
-          onClick={preventPropagation}
-        >
+      <div className={css({ ...cannotLoginModalWrapperStyles })} onClick={handleCloseModal}>
+        <div className={css({ ...cannotLoginModalStyles })} onClick={preventPropagation}>
           <h1 className={css({ ...modalTitleStyles })}>
             <IconAlertCircle className={css({ ...iconAlertCircleStyles })} />
             <span>로그인이 안 되나요?</span>
           </h1>
           <li className={css({ ...buttonListStyles })}>
             <CannotLoginModalButton onClick={handleClickLoginAccountButton}>
-              로그인한 계정을 알고 싶어요.
+              로그인 했던 방법을 알고 싶어요.
             </CannotLoginModalButton>
             <Link to="/social-account-linking/auth">
-              <CannotLoginModalButton>
-                소셜 계정을 재설정하고 싶어요.
-              </CannotLoginModalButton>
+              <CannotLoginModalButton>로그인 계정을 변경하고 싶어요.</CannotLoginModalButton>
             </Link>
             <CannotLoginModalButton onClick={handleClickKakaoChannelButton}>
               카카오톡 채널에 문의할게요.
@@ -59,68 +51,68 @@ function CannotLoginModal({ handleCloseModal }: CannotLoginModalProps) {
 export default CannotLoginModal;
 
 const cannotLoginModalWrapperStyles = css.raw({
-  position: "absolute",
-  top: "0",
-  left: "0",
-  zIndex: "1",
+  position: 'absolute',
+  top: '0',
+  left: '0',
+  zIndex: '1',
 
-  display: "flex",
-  justifyContent: "center",
+  display: 'flex',
+  justifyContent: 'center',
 
-  width: "100%",
-  height: "100vh",
+  width: '100%',
+  height: '100vh',
 
-  backgroundColor: "grayAlpha.800",
+  backgroundColor: 'grayAlpha.800',
 
-  "@media (max-width: 480px)": {
-    alignItems: "flex-end",
+  '@media (max-width: 480px)': {
+    alignItems: 'flex-end',
   },
 });
 
 const cannotLoginModalStyles = css.raw({
-  width: "41rem",
-  height: "22.2rem",
-  padding: "0 0.8rem",
-  marginTop: "2.8rem",
+  width: '41rem',
+  height: '22.2rem',
+  padding: '0 0.8rem',
+  marginTop: '2.8rem',
 
-  borderRadius: "1.6rem",
+  borderRadius: '1.6rem',
 
-  backgroundColor: "gray.800",
+  backgroundColor: 'gray.800',
 
-  "@media (max-width: 480px)": {
-    width: "calc(100% - 3.2rem)",
-    height: "20.6rem",
-    marginBottom: "0.8rem",
+  '@media (max-width: 480px)': {
+    width: 'calc(100% - 3.2rem)',
+    height: '20.6rem',
+    marginBottom: '0.8rem',
   },
 });
 
 const modalTitleStyles = css.raw({
-  display: "flex",
-  alignItems: "center",
-  gap: "0.4rem",
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.4rem',
 
-  marginTop: "1.6rem",
-  paddingLeft: "0.4rem",
+  marginTop: '1.6rem',
+  paddingLeft: '0.4rem',
 
-  textStyle: " title-4-20-sb",
-  color: "gray.10",
+  textStyle: ' title-4-20-sb',
+  color: 'gray.10',
 });
 
 const iconAlertCircleStyles = css.raw({
-  width: "2.4rem",
-  height: "2.4rem",
+  width: '2.4rem',
+  height: '2.4rem',
 
-  color: "white",
+  color: 'white',
 });
 
 const buttonListStyles = css.raw({
-  display: "flex",
-  flexDirection: "column",
-  gap: "1.2rem",
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1.2rem',
 
-  marginTop: "1.2rem",
+  marginTop: '1.2rem',
 
-  "@media (max-width: 480px)": {
-    gap: "0.4rem",
+  '@media (max-width: 480px)': {
+    gap: '0.4rem',
   },
 });

--- a/src/components/login-error/ReLoginSection.tsx
+++ b/src/components/login-error/ReLoginSection.tsx
@@ -1,11 +1,13 @@
-"use client";
+'use client';
 
-import { css } from "@/styled-system/css";
-import { IconChevronRight } from "@sopt-makers/icons";
-import { useState } from "react";
-import CannotLoginModal from "@/src/components/common/CannotLoginModal";
+import { css } from '@/styled-system/css';
+import { IconChevronRight } from '@sopt-makers/icons';
+import { useState } from 'react';
+import CannotLoginModal from '@/src/components/common/CannotLoginModal';
+import { useNavigate } from '@tanstack/react-router';
 
 function ReLoginSection() {
+  const navigate = useNavigate();
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
   const handleClickCannotLoginButton = () => {
     setIsModalOpen(true);
@@ -15,20 +17,19 @@ function ReLoginSection() {
     setIsModalOpen(false);
   };
 
+  const navigateToHome = () => {
+    navigate({ to: '/' });
+  };
+
   return (
     <>
       {isModalOpen && <CannotLoginModal handleCloseModal={handleCloseModal} />}
       <div className={css({ ...reLoginSectionStyles })}>
-        <button className={css({ ...reLoginButtonStyles })}>
+        <button className={css({ ...reLoginButtonStyles })} onClick={navigateToHome}>
           다시 로그인하기
         </button>
-        <button
-          className={css({ ...cannotLoginButtonStyles })}
-          onClick={handleClickCannotLoginButton}
-        >
-          <span className={css({ ...cannotLoginButtonTextStyles })}>
-            로그인이 안 되나요?
-          </span>
+        <button className={css({ ...cannotLoginButtonStyles })} onClick={handleClickCannotLoginButton}>
+          <span className={css({ ...cannotLoginButtonTextStyles })}>로그인이 안 되나요?</span>
           <IconChevronRight className={css({ ...iconChevronRightStyles })} />
         </button>
       </div>
@@ -39,60 +40,60 @@ function ReLoginSection() {
 export default ReLoginSection;
 
 const reLoginSectionStyles = css.raw({
-  display: "flex",
-  flexDirection: "column",
-  alignItems: "center",
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
 
-  marginTop: "6.6rem",
+  marginTop: '6.6rem',
 
-  "@media (max-width: 480px)": {
-    marginTop: "0",
-    marginBottom: "2.4rem",
+  '@media (max-width: 480px)': {
+    marginTop: '0',
+    marginBottom: '2.4rem',
   },
 });
 
 const reLoginButtonStyles = css.raw({
-  width: "32rem",
-  height: "5.6rem",
+  width: '32rem',
+  height: '5.6rem',
 
-  borderRadius: "1.2rem",
-  backgroundColor: "white",
+  borderRadius: '1.2rem',
+  backgroundColor: 'white',
 
-  textStyle: "label-1-18-sb",
+  textStyle: 'label-1-18-sb',
 
-  "&:hover": {
-    cursor: "pointer",
-    backgroundColor: "gray.50",
+  '&:hover': {
+    cursor: 'pointer',
+    backgroundColor: 'gray.50',
   },
 
-  "&:active": {
-    backgroundColor: "gray.100",
+  '&:active': {
+    backgroundColor: 'gray.100',
   },
 });
 
 const cannotLoginButtonStyles = css.raw({
-  display: "flex",
-  alignItems: "center",
+  display: 'flex',
+  alignItems: 'center',
 
-  marginTop: "1.6rem",
+  marginTop: '1.6rem',
 
-  color: "gray.30",
+  color: 'gray.30',
 
-  "&:hover": {
-    cursor: "pointer",
-    color: "gray.50",
+  '&:hover': {
+    cursor: 'pointer',
+    color: 'gray.50',
   },
 
-  "&:active": {
-    color: "gray.100",
+  '&:active': {
+    color: 'gray.100',
   },
 });
 
 const cannotLoginButtonTextStyles = css.raw({
-  textStyle: "label-3-14-sb",
+  textStyle: 'label-3-14-sb',
 });
 
 const iconChevronRightStyles = css.raw({
-  width: "1.6rem",
-  height: "1.6rem",
+  width: '1.6rem',
+  height: '1.6rem',
 });

--- a/src/hooks/useLogin.ts
+++ b/src/hooks/useLogin.ts
@@ -29,8 +29,7 @@ export const useLogin = () => {
       window.location.href = VITE_SUCCESS_CALLBACK;
     } catch (error) {
       if (error instanceof Error) {
-        alert(error.message);
-        navigate({ to: '/', replace: true });
+        navigate({ to: '/login-error', replace: true });
       }
     }
   };

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -4,16 +4,19 @@ import { css } from '@/styled-system/css';
 import './index.css';
 import '@sopt-makers/ui/dist/index.css';
 import '@/src/utils/apple';
+import { ToastProvider } from '@sopt-makers/ui';
 
 export const Route = createRootRoute({
   component: () => (
     <>
-      <div
-        className={css({
-          ...rootLayoutStyle,
-        })}>
-        <Outlet />
-      </div>
+      <ToastProvider>
+        <div
+          className={css({
+            ...rootLayoutStyle,
+          })}>
+          <Outlet />
+        </div>
+      </ToastProvider>
       <TanStackRouterDevtools />
     </>
   ),

--- a/src/routes/login-error/index.tsx
+++ b/src/routes/login-error/index.tsx
@@ -2,6 +2,7 @@ import ReLoginSection from '@/src/components/login-error/ReLoginSection';
 import { css } from '@/styled-system/css';
 import { createFileRoute } from '@tanstack/react-router';
 import loginErrorIcon from '@/src/assets/login_error.svg';
+import makersLogo from '@/src/assets/makers.png';
 
 export const Route = createFileRoute('/login-error/')({
   component: Index,
@@ -39,7 +40,7 @@ function Index() {
             className={css({
               ...makersImgStyles,
             })}
-            src="/makers.png"
+            src={makersLogo}
             alt="makers 로고"
           />
         </a>

--- a/src/utils/formatter.ts
+++ b/src/utils/formatter.ts
@@ -1,5 +1,22 @@
 export const formatTime = (time: number): string => {
   const minutes = Math.floor(time / 60);
   const seconds = time % 60;
-  return `${minutes}:${seconds.toString().padStart(2, "0")}`;
+  return `${minutes}:${seconds.toString().padStart(2, '0')}`;
+};
+
+export const formatPhoneNumber = (phone: string): string => {
+  const digits = phone.replace(/\D/g, '').slice(0, 11); // 최대 11자리
+  const len = digits.length;
+
+  if (len <= 3) {
+    return digits;
+  } else if (len <= 7) {
+    return digits.replace(/(\d{3})(\d{1,4})/, '$1-$2'); // 010-1234
+  } else {
+    return digits.replace(/(\d{3})(\d{4})(\d{1,4})/, '$1-$2-$3'); // 010-1234-5678
+  }
+};
+
+export const extractPhoneDigits = (phone: string): string => {
+  return phone.replace(/[^0-9]/g, '');
 };

--- a/src/utils/formatter.ts
+++ b/src/utils/formatter.ts
@@ -5,15 +5,15 @@ export const formatTime = (time: number): string => {
 };
 
 export const formatPhoneNumber = (phone: string): string => {
-  const digits = phone.replace(/\D/g, '').slice(0, 11); // 최대 11자리
+  const digits = phone.replace(/\D/g, '').slice(0, 11);
   const len = digits.length;
 
   if (len <= 3) {
     return digits;
   } else if (len <= 7) {
-    return digits.replace(/(\d{3})(\d{1,4})/, '$1-$2'); // 010-1234
+    return digits.replace(/(\d{3})(\d{1,4})/, '$1-$2');
   } else {
-    return digits.replace(/(\d{3})(\d{4})(\d{1,4})/, '$1-$2-$3'); // 010-1234-5678
+    return digits.replace(/(\d{3})(\d{4})(\d{1,4})/, '$1-$2-$3');
   }
 };
 

--- a/src/utils/validator.ts
+++ b/src/utils/validator.ts
@@ -1,0 +1,4 @@
+export function isValidPhone(phone: string): boolean {
+  const re = /^010-?\d{4}-?\d{4}$/;
+  return re.test(phone);
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -4,4 +4,6 @@ interface ImportMetaEnv {
   readonly VITE_API_URL: string;
   readonly VITE_GOOGLE_CLIENT_ID: string;
   readonly VITE_GOOGLE_REDIRECT_URI: string;
+  readonly VITE_APPLE_REDIRECT_URI: string;
+  readonly VITE_KAKAO_CHANNEL_URL: string;
 }


### PR DESCRIPTION
related issue #44 

- [ 전화 번호 인증 화면 ]
  - 전화번호 정상 입력일 때만 전송하기 버튼 활성화
  - 인증 번호 전송 후 유효시간인 3분이 지났을 때 전송하기 버튼 활성화
  - 인증 번호 전송하기 버튼을 눌렀을 때만 인증번호 입력 필드 활성화
  - 시간이 3분이 아닐 때만 활성화 ( 활성화 상태에서 3분이 되면 input창 clear)
  - 인증 번호가 전송되었어요 토스트 구현

- [ 소셜계정 재설정 ]
  - 인증 번호 전송 / 인증 번호 검증 API 파라미터 값 REGISTER -> CHANGE_SOCIAL_PLATFROM으로 변경

- [ 바텀 시트 ]
  - 로그인했던 계정을 알고싶어요 -> 계정 찾기 화면으로 넘어가기 (근데 이거 피그마에 디자인이 없음)
  - 카카오톡 채널 문의로 안넘어 가는 이슈